### PR TITLE
Ajout d'une propriété info pour obtenir l'IP courante à partir de l'@ MAC en mode ARP

### DIFF
--- a/core/ajax/ping.ajax.php
+++ b/core/ajax/ping.ajax.php
@@ -53,4 +53,3 @@ try {
 } catch (Exception $e) {
     ajax::error(displayExeption($e), $e->getCode());
 }
-?>

--- a/core/class/ping.class.php
+++ b/core/class/ping.class.php
@@ -130,7 +130,7 @@ class ping extends eqLogic {
 			$cmd->setName('Ping');
 			$cmd->setEqLogic_id($this->getId());
 			$cmd->setType('action');
-			$cmd->setSubType('string');
+			$cmd->setSubType('other');
 			$cmd->setLogicalId('ping');
 			$cmd->setEventOnly(1);
 			$cmd->setDisplay('icon','<i class="icon techno-fleches"></i>');

--- a/core/i18n/tr.json
+++ b/core/i18n/tr.json
@@ -40,6 +40,6 @@
     "plugins\/ping\/plugin_info\/configuration.php": {
         "Commande ping": "Commande ping",
         "Commande arp-scan": "Commande arp-scan",
-        "Detecter les programme ping et arp-scan": "Detecter les programme ping et arp-scan"
+        "Detecter les programme ping et arp-scan": "Detecter les programmes ping et arp-scan"
     }
 }

--- a/desktop/js/ping.js
+++ b/desktop/js/ping.js
@@ -1,186 +1,196 @@
 function addCmdToTable(_cmd) {
-   if (!isset(_cmd)) {
-        var _cmd = {configuration: {}};
-    }
-    if (!isset(_cmd.configuration)) {
-        _cmd.configuration = {};
-    }
+  if (!isset(_cmd)) {
+    var _cmd = { configuration: {} };
+  }
+  if (!isset(_cmd.configuration)) {
+    _cmd.configuration = {};
+  }
 
-    if (init(_cmd.type) == 'info') {
-        var tr = '<tr class="cmd" data-cmd_id="' + init(_cmd.id) + '" >';
-        tr += '<td>';
-        tr += '<span class="cmdAttr" data-l1key="id"></span>';
-        tr += '<input class="cmdAttr form-control input-sm" data-l1key="name" placeholder="{{Nom}}"></td>';
-		tr += '</td>';
-		tr += '<td>';
-		tr += '<a class="cmdAction btn btn-default btn-sm" data-l1key="chooseIcon"><i class="fa fa-flag"></i> Icone</a>';
-		tr += '<span class="cmdAttr cmdAction" data-l1key="display" data-l2key="icon" style="margin-left : 10px;"></span>';
-        tr += '</td>';
-		tr += '<td class="expertModeVisible">';
-        tr += '<input class="cmdAttr form-control type input-sm" data-l1key="type" value="action" disabled style="margin-bottom : 5px;" />';
-        tr += '<span class="cmdAttr subType" subType="' + init(_cmd.subType) + '"></span>';
-		tr += '<input type=hidden class="cmdAttr form-control input-sm" data-l1key="unite" value="">';
-        tr += '</td>';
-        tr += '<td>';
-		tr += '<span><input type="checkbox" class="cmdAttr" data-l1key="isHistorized"/> {{Historiser}}<br/></span>';
-        tr += '<span><input type="checkbox" class="cmdAttr" data-l1key="isVisible" checked/> {{Afficher}}<br/></span>';
-        tr += '</td>';
-//		tr += '<td><i class="fa fa-minus-circle pull-right cmdAction cursor" data-action="remove"></i></td>';		
-        tr += '<td>';
-        if (is_numeric(_cmd.id)) {
-            tr += '<a class="btn btn-default btn-xs cmdAction expertModeVisible" data-action="configure"><i class="fa fa-cogs"></i></a> ';
-        }
-        tr += '</td>';
-		table_cmd = '#table_cmd';
-		if ( $(table_cmd+'_'+_cmd.eqType ).length ) {
-			table_cmd+= '_'+_cmd.eqType;
-		}
-        $(table_cmd+' tbody').append(tr);
-        $(table_cmd+' tbody tr:last').setValues(_cmd, '.cmdAttr');
+  if (init(_cmd.type) == "info") {
+    
+    var tr = '<tr class="cmd" data-cmd_id="' + init(_cmd.id) + '" >';
+    tr += "<td>";
+    tr += '<span class="cmdAttr" data-l1key="id"></span>';
+    tr += '<input class="cmdAttr form-control input-sm" data-l1key="name" placeholder="{{Nom}}"></td>';
+    tr += "</td>";
+    tr += "<td>";
+    tr += '<a class="cmdAction btn btn-default btn-sm" data-l1key="chooseIcon"><i class="fa fa-flag"></i> Icone</a>';
+    tr += '<span class="cmdAttr cmdAction" data-l1key="display" data-l2key="icon" style="margin-left : 10px;"></span>';
+    tr += "</td>";
+    tr += '<td class="expertModeVisible">';
+    tr += '<input class="cmdAttr form-control type input-sm" data-l1key="type" value="action" disabled style="margin-bottom : 5px;" />';
+    tr += '<span class="cmdAttr subType" subType="' + init(_cmd.subType) + '"></span>';
+    tr += '<input type=hidden class="cmdAttr form-control input-sm" data-l1key="unite" value="">';
+    tr += "</td>";
+    tr += "<td>";
+    tr += '<span><input type="checkbox" class="cmdAttr" data-l1key="isHistorized"/> {{Historiser}}<br/></span>';
+    tr += '<span><input type="checkbox" class="cmdAttr" data-l1key="isVisible" checked/> {{Afficher}}<br/></span>';
+    tr += "</td>";
+    //		tr += '<td><i class="fa fa-minus-circle pull-right cmdAction cursor" data-action="remove"></i></td>';
+    tr += "<td>";
+    if (is_numeric(_cmd.id)) {
+      tr += '<a class="btn btn-default btn-xs cmdAction expertModeVisible" data-action="configure"><i class="fa fa-cogs"></i></a> ';
     }
-    if (init(_cmd.type) == 'action') {
-        var tr = '<tr class="cmd" data-cmd_id="' + init(_cmd.id) + '">';
-        tr += '<td>';
-        tr += '<span class="cmdAttr" data-l1key="id"></span>';
-        tr += '<input class="cmdAttr form-control input-sm" data-l1key="name" placeholder="{{Nom}}">';
-		tr += '</td>';
-        tr += '<td>';
-		tr += '<a class="cmdAction btn btn-default btn-sm" data-l1key="chooseIcon"><i class="fa fa-flag"></i> Icone</a>';
-		tr += '<span class="cmdAttr cmdAction" data-l1key="display" data-l2key="icon" style="margin-left : 10px;"></span>';
-        tr += '</td>';
-        tr += '<td>';
-        tr += '<input class="cmdAttr form-control type input-sm" data-l1key="type" value="action" disabled style="margin-bottom : 5px;" />';
-        tr += '<span class="subType" subType="' + init(_cmd.subType) + '"></span>';
-        tr += '</td>';
-        tr += '<td>';
-        tr += '<span><input type="checkbox" class="cmdAttr" data-l1key="isVisible" checked/> {{Afficher}}<br/></span>';
-        tr += '</td>';
-        tr += '<td>';
-        if (is_numeric(_cmd.id)) {
-            tr += '<a class="btn btn-default btn-xs cmdAction expertModeVisible" data-action="configure"><i class="fa fa-cogs"></i></a> ';
-            tr += '<a class="btn btn-default btn-xs cmdAction" data-action="test"><i class="fa fa-rss"></i> {{Tester}}</a>';
-        }
-//		tr += '<td><i class="fa fa-minus-circle pull-right cmdAction cursor" data-action="remove"></i></td>';
-		tr += '</tr>';
+    tr += "</td>";
+    table_cmd = "#table_cmd";
+    if ($(table_cmd + "_" + _cmd.eqType).length) {
+      table_cmd += "_" + _cmd.eqType;
+    }
+    $(table_cmd + " tbody").append(tr);
+    $(table_cmd + " tbody tr:last").setValues(_cmd, ".cmdAttr");
+  }
+  if (init(_cmd.type) == "action") {
+    var tr = '<tr class="cmd" data-cmd_id="' + init(_cmd.id) + '">';
+    tr += "<td>";
+    tr += '<span class="cmdAttr" data-l1key="id"></span>';
+    tr += '<input class="cmdAttr form-control input-sm" data-l1key="name" placeholder="{{Nom}}">';
+    tr += "</td>";
+    tr += "<td>";
+    tr += '<a class="cmdAction btn btn-default btn-sm" data-l1key="chooseIcon"><i class="fa fa-flag"></i> Icone</a>';
+    tr += '<span class="cmdAttr cmdAction" data-l1key="display" data-l2key="icon" style="margin-left : 10px;"></span>';
+    tr += "</td>";
+    tr += "<td>";
+    tr += '<input class="cmdAttr form-control type input-sm" data-l1key="type" value="action" disabled style="margin-bottom : 5px;" />';
+    tr += '<span class="subType" subType="' + init(_cmd.subType) + '"></span>';
+    tr += "</td>";
+    tr += "<td>";
+    tr += '<span><input type="checkbox" class="cmdAttr" data-l1key="isVisible" checked/> {{Afficher}}<br/></span>';
+    tr += "</td>";
+    tr += "<td>";
+    if (is_numeric(_cmd.id)) {
+      tr += '<a class="btn btn-default btn-xs cmdAction expertModeVisible" data-action="configure"><i class="fa fa-cogs"></i></a> ';
+      tr += '<a class="btn btn-default btn-xs cmdAction" data-action="test"><i class="fa fa-rss"></i> {{Tester}}</a>';
+    }
+    //		tr += '<td><i class="fa fa-minus-circle pull-right cmdAction cursor" data-action="remove"></i></td>';
+    tr += "</tr>";
 
-		table_cmd = '#table_cmd';
-		if ( $(table_cmd+'_'+_cmd.eqType ).length ) {
-			table_cmd+= '_'+_cmd.eqType;
-		}
-        $(table_cmd+' tbody').append(tr);
-        $(table_cmd+' tbody tr:last').setValues(_cmd, '.cmdAttr');
-        var tr = $(table_cmd+' tbody tr:last');
-        jeedom.eqLogic.builSelectCmd({
-            id: $(".li_eqLogic.active").attr('data-eqLogic_id'),
-            filter: {type: 'info'},
-            error: function (error) {
-                $('#div_alert').showAlert({message: error.message, level: 'danger'});
-            },
-            success: function (result) {
-                tr.find('.cmdAttr[data-l1key=value]').append(result);
-                tr.setValues(_cmd, '.cmdAttr');
-            }
-        });
+    table_cmd = "#table_cmd";
+    if ($(table_cmd + "_" + _cmd.eqType).length) {
+      table_cmd += "_" + _cmd.eqType;
     }
+    $(table_cmd + " tbody").append(tr);
+    $(table_cmd + " tbody tr:last").setValues(_cmd, ".cmdAttr");
+    var tr = $(table_cmd + " tbody tr:last");
+    jeedom.eqLogic.builSelectCmd({
+      id: $(".li_eqLogic.active").attr("data-eqLogic_id"),
+      filter: { type: "info" },
+      error: function (error) {
+        $("#div_alert").showAlert({ message: error.message, level: "danger" });
+      },
+      success: function (result) {
+        tr.find(".cmdAttr[data-l1key=value]").append(result);
+        tr.setValues(_cmd, ".cmdAttr");
+      },
+    });
+  }
 }
 
-$("#table_cmd").sortable({axis: "y", cursor: "move", items: ".cmd", placeholder: "ui-state-highlight", tolerance: "intersect", forcePlaceholderSize: true});
+$("#table_cmd").sortable({
+  axis: "y",
+  cursor: "move",
+  items: ".cmd",
+  placeholder: "ui-state-highlight",
+  tolerance: "intersect",
+  forcePlaceholderSize: true,
+});
 
-$(function(){
-	$('input[type=radio][name=mode]').change(function(){
-		if ( $(this).val() == 'Icmp' )
-		{
-			$("#port").hide();
-			$("#ip").show();
-			$("#mac").hide();
-			$("#interface").hide();
-		}
-		else if ( $(this).val() == 'Arp' )
-		{
-			$("#port").hide();
-			$("#ip").hide();
-			$("#mac").show();
-			$("#interface").show();
-		}
-		else
-		{
-			$("#ip").show();
-			$("#mac").hide();
-			$("#port").show();
-			$("#interface").hide();
-		}
-	})
-})
+$(function () {
+  $("input[type=radio][name=mode]").change(function () {
+    if ($(this).val() == "Icmp") {
+      $("#port").hide();
+      $("#ip").show();
+      $("#mac").hide();
+      $("#interface").hide();
+    } else if ($(this).val() == "Arp") {
+      $("#port").hide();
+      $("#ip").hide();
+      $("#mac").show();
+      $("#interface").show();
+    } else {
+      $("#ip").show();
+      $("#mac").hide();
+      $("#port").show();
+      $("#interface").hide();
+    }
+  });
+});
 
 function saveEqLogic(_eqLogic) {
-	_eqLogic.configuration.mode = $('input[type=radio][name=mode]:checked').val();
-	return _eqLogic;
+  _eqLogic.configuration.mode = $("input[type=radio][name=mode]:checked").val();
+  return _eqLogic;
 }
 
 function printEqLogic(_eqLogic) {
-	if (isset(_eqLogic.configuration) && isset(_eqLogic.configuration.mode) && _eqLogic.configuration.mode != '') {
-		$('input[type=radio][name=mode][value='+_eqLogic.configuration.mode+']').prop('checked', true);
-		if ( _eqLogic.configuration.mode == 'Icmp' )
-		{
-			$("#port").hide();
-			$("#ip").show();
-			$("#mac").hide();
-			$("#interface").hide();
-		}
-		else if ( _eqLogic.configuration.mode == 'Arp' )
-		{
-			$("#port").hide();
-			$("#ip").hide();
-			$("#mac").show();
-			$("#interface").show();
-		}
-		else
-		{
-			$("#ip").show();
-			$("#mac").hide();
-			$("#port").show();
-			$("#interface").hide();
-		}
-	}
-	else
-	{
-		$('input[type=radio][name=mode][value=Tcp]').prop('checked', true);
-		$("#ip").show();
-		$("#mac").hide();
-		$("#port").show();
-		$("#interface").hide();
-	}
+  if (isset(_eqLogic.configuration) && isset(_eqLogic.configuration.mode) && _eqLogic.configuration.mode != "") {
+    $("input[type=radio][name=mode][value=" + _eqLogic.configuration.mode + "]").prop("checked", true);
+    if (_eqLogic.configuration.mode == "Icmp") {
+      $("#port").hide();
+      $("#ip").show();
+      $("#mac").hide();
+      $("#interface").hide();
+    } else if (_eqLogic.configuration.mode == "Arp") {
+      $("#port").hide();
+      $("#ip").hide();
+      $("#mac").show();
+      $("#interface").show();
+    } else {
+      $("#ip").show();
+      $("#mac").hide();
+      $("#port").show();
+      $("#interface").hide();
+    }
+  } else {
+    $("input[type=radio][name=mode][value=Tcp]").prop("checked", true);
+    $("#ip").show();
+    $("#mac").hide();
+    $("#port").show();
+    $("#interface").hide();
+  }
 }
 
-$('#bt_DetectBin').on('click', function() {
-    $.ajax({// fonction permettant de faire de l'ajax
-        type: "POST", // methode de transmission des données au fichier php
-        url: "plugins/ping/core/ajax/ping.ajax.php", // url du fichier php
-        data: {
-            action: "DetectBin",
+$("#bt_DetectBin").on("click", function () {
+  $.ajax({
+    // fonction permettant de faire de l'ajax
+    type: "POST", // methode de transmission des données au fichier php
+    url: "plugins/ping/core/ajax/ping.ajax.php", // url du fichier php
+    data: {
+      action: "DetectBin",
+    },
+    dataType: "json",
+    error: function (request, status, error) {
+      handleAjaxError(request, status, $("#div_DetectBin"));
+    },
+    success: function (data) {
+      // si l'appel a bien fonctionné
+      if (data.state != "ok") {
+        $("#div_DetectBin").showAlert({
+          message: data.result,
+          level: "danger",
+        });
+      } else {
+        $("#div_DetectBin").showAlert({
+          message: data.result,
+          level: "success",
+        });
+      }
+      jeedom.config.load({
+        configuration: $("#config").getValues(".configKey")[0],
+        plugin: "ping",
+        error: function (error) {
+          $("#div_alert").showAlert({
+            message: error.message,
+            level: "danger",
+          });
         },
-        dataType: 'json',
-        error: function(request, status, error) {
-            handleAjaxError(request, status, $('#div_DetectBin'));
+        success: function (data) {
+          $("#config").setValues(data, ".configKey");
+          modifyWithoutSave = false;
+          $("#div_alert").showAlert({
+            message: "{{Sauvegarde réussie}}",
+            level: "success",
+          });
         },
-        success: function(data) { // si l'appel a bien fonctionné
-			if (data.state != 'ok') {
-				$('#div_DetectBin').showAlert({message: data.result, level: 'danger'});
-			} else {
-				$('#div_DetectBin').showAlert({message: data.result, level: 'success'});
-			}
-			jeedom.config.load({
-                configuration: $('#config').getValues('.configKey')[0],
-				plugin: 'ping',
-                error: function (error) {
-                    $('#div_alert').showAlert({message: error.message, level: 'danger'});
-                },
-                success: function (data) {
-                    $('#config').setValues(data, '.configKey');
-                    modifyWithoutSave = false;
-                    $('#div_alert').showAlert({message: '{{Sauvegarde réussie}}', level: 'success'});
-                }
-            });
-        }
-    });
+      });
+    },
+  });
 });

--- a/desktop/php/ping.php
+++ b/desktop/php/ping.php
@@ -11,45 +11,45 @@ sendVarToJS('eqType', 'ping');
             <ul id="ul_eqLogic" class="nav nav-list bs-sidenav">
                 <a class="btn btn-default eqLogicAction" style="width : 100%;margin-top : 5px;margin-bottom: 5px;" data-action="add"><i class="fa fa-plus-circle"></i> {{Ajouter un Ping}}</a>
                 <?php
-				$eqLogics = eqLogic::byType('ping');
-				foreach ($eqLogics as $eqLogic) {
-                    echo '<li>'."\n";
-						echo '<a class="cursor li_eqLogic" data-eqLogic_id="' . $eqLogic->getId() . '" data-eqLogic_type="ping"><i class="fa fa-download"></i> ' . $eqLogic->getName() . '</a>'."\n";
-					echo '</li>'."\n";
+                $eqLogics = eqLogic::byType('ping');
+                foreach ($eqLogics as $eqLogic) {
+                    echo '<li>' . "\n";
+                    echo '<a class="cursor li_eqLogic" data-eqLogic_id="' . $eqLogic->getId() . '" data-eqLogic_type="ping"><i class="fa fa-download"></i> ' . $eqLogic->getName() . '</a>' . "\n";
+                    echo '</li>' . "\n";
                 }
                 ?>
             </ul>
         </div>
     </div>
     <div class="col-lg-9 col-md-9 col-sm-8 eqLogicThumbnailDisplay" style="border-left: solid 1px #EEE; padding-left: 25px;">
-  <legend><i class="fa fa-cog"></i>  {{Gestion}}</legend>
-   <div class="eqLogicThumbnailContainer">
-    <div class="cursor eqLogicAction" data-action="add" style="background-color : #ffffff; height : 120px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;" >
-     <center>
-      <i class="fa fa-plus-circle" style="font-size : 6em;color:#94ca02;"></i>
-    </center>
-    <span style="font-size : 1.1em;position:relative; top : 15px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;color:#94ca02"><center>Ajouter</center></span>
-  </div>
-  <div class="cursor eqLogicAction" data-action="gotoPluginConf" style="background-color : #ffffff; height : 120px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;">
-    <center>
-      <i class="fa fa-wrench" style="font-size : 6em;color:#767676;"></i>
-    </center>
-    <span style="font-size : 1.1em;position:relative; top : 15px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;color:#767676"><center>{{Configuration}}</center></span>
-  </div>
-</div>
+        <legend><i class="fa fa-cog"></i> {{Gestion}}</legend>
+        <div class="eqLogicThumbnailContainer">
+            <div class="cursor eqLogicAction" data-action="add" style="background-color : #ffffff; height : 120px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;">
+                <center>
+                    <i class="fa fa-plus-circle" style="font-size : 6em;color:#94ca02;"></i>
+                </center>
+                <center>Ajouter</center>
+            </div>
+            <div class="cursor eqLogicAction" data-action="gotoPluginConf" style="background-color : #ffffff; height : 120px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;">
+                <center>
+                    <i class="fa fa-wrench" style="font-size : 6em;color:#767676;"></i>
+                </center>
+                <center>{{Configuration}}</center>
+            </div>
+        </div>
         <legend>{{Mes Pings}}
         </legend>
-		<div class="eqLogicThumbnailContainer">
-			<div class="cursor eqLogicAction" data-action="add" style="background-color : #ffffff; height : 200px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;" >
-				<center>
-				<i class="fa fa-plus-circle" style="font-size : 7em;color:#94ca02;"></i>
-				</center>
-				<span style="font-size : 1.1em;position:relative; top : 23px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;color:#94ca02"><center>Ajouter</center></span>
-			</div>
-			<?php
-	        if (count($eqLogics) == 0) {
-				echo "<br/><br/><br/><center><span style='color:#767676;font-size:1.2em;font-weight: bold;'>{{Vous n'avez pas encore de ping, cliquez sur Ajouter un équipement pour commencer}}</span></center>";
-			} else {
+        <div class="eqLogicThumbnailContainer">
+            <div class="eqLogicDisplayCard cursor" data-action="add" style="background-color : #ffffff; height : 200px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;" >
+                <center>
+                    <i class="fa fa-plus-circle" style="font-size : 7em;color:#94ca02;"></i>
+                </center>
+                <center>Ajouter</center>
+            </div>
+            <?php
+            if (count($eqLogics) == 0) {
+                echo "<br/><br/><br/><center><span style='color:#767676;font-size:1.2em;font-weight: bold;'>{{Vous n'avez pas encore de ping, cliquez sur Ajouter un équipement pour commencer}}</span></center>";
+            } else {
                 foreach ($eqLogics as $eqLogic) {
                     echo '<div class="eqLogicDisplayCard cursor" data-eqLogic_id="' . $eqLogic->getId() . '" style="background-color : #ffffff; height : 200px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;" >';
                     echo "<center>";
@@ -58,32 +58,32 @@ sendVarToJS('eqType', 'ping');
                     echo ' <span style="font-size : 1.1em;position:relative; top : 15px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;"> <center>' . $eqLogic->getHumanName(true, true) . '</center></span>';
                     echo '</div>';
                 }
-                ?>
-            </div>
-        <?php } ?>
+            ?>
+        </div>
+    <?php } ?>
     </div>
     <div class="col-lg-9 eqLogic ping" style="border-left: solid 1px #EEE; padding-left: 25px;display: none;">
         <form class="form-horizontal">
             <fieldset>
                 <legend>
                     {{Général}}
-				   <i class='fa fa-cogs eqLogicAction pull-right cursor expertModeVisible' data-action='configure'></i>
-			   </legend>
+                    <i class='fa fa-cogs eqLogicAction pull-right cursor expertModeVisible' data-action='configure'></i>
+                </legend>
                 <div class="form-group">
                     <label class="col-lg-2 control-label">{{Nom de l'équipement}}</label>
                     <div class="col-lg-3">
                         <input type="text" class="eqLogicAttr form-control" data-l1key="id" style="display : none;" />
-                        <input type="text" class="eqLogicAttr form-control" data-l1key="name" placeholder="{{Nom de la ping}}"/>
+                        <input type="text" class="eqLogicAttr form-control" data-l1key="name" placeholder="{{Nom de la ping}}" />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-lg-2 control-label" >{{Objet parent}}</label>
+                    <label class="col-lg-2 control-label">{{Objet parent}}</label>
                     <div class="col-lg-3">
                         <select class="form-control eqLogicAttr" data-l1key="object_id">
                             <option value="">{{Aucun}}</option>
                             <?php
                             foreach (jeeObject::all() as $object) {
-                                echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>'."\n";
+                                echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>' . "\n";
                             }
                             ?>
                         </select>
@@ -94,61 +94,65 @@ sendVarToJS('eqType', 'ping');
                     <div class="col-lg-8">
                         <?php
                         foreach (jeedom::getConfiguration('eqLogic:category') as $key => $value) {
-                            echo '<label class="checkbox-inline">'."\n";
+                            echo '<label class="checkbox-inline">' . "\n";
                             echo '<input type="checkbox" class="eqLogicAttr" data-l1key="category" data-l2key="' . $key . '" />' . $value['name'];
-                            echo '</label>'."\n";
+                            echo '</label>' . "\n";
                         }
                         ?>
 
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-md-2 control-label" >{{Activer}}</label>
+                    <label class="col-md-2 control-label">{{Activer}}</label>
                     <div class="col-md-1">
-                        <input type="checkbox" class="eqLogicAttr" data-l1key="isEnable" checked/>
+                        <input type="checkbox" class="eqLogicAttr" data-l1key="isEnable" checked />
                     </div>
-                    <label class="col-lg-2 control-label" >{{Visible}}</label>
+                    <label class="col-lg-2 control-label">{{Visible}}</label>
                     <div class="col-lg-1">
-                        <input type="checkbox" class="eqLogicAttr" data-l1key="isVisible" checked/>
+                        <input type="checkbox" class="eqLogicAttr" data-l1key="isVisible" checked />
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="col-lg-2 control-label">{{Mode}}</label>
                     <div class="col-lg-3">
-						<input type="hidden" class="eqLogicAttr" data-l1key="configuration" data-l2key="mode" id="eqLogicMode">
-						<label class="checkbox-inline"><input type="radio" value="Arp" name="mode" <?php if ( config::byKey('cmd_arp', 'ping') == '' ) {print(" disabled");}?> />Arp</label>
-						<label class="checkbox-inline"><input type="radio" value="Icmp" name="mode" <?php if ( config::byKey('cmd_ping', 'ping') == '' ) {print(" disabled");}?>/>Icmp</label>
-						<label class="checkbox-inline"><input type="radio" value="Tcp" name="mode" />Tcp</label>
+                        <input type="hidden" class="eqLogicAttr" data-l1key="configuration" data-l2key="mode" id="eqLogicMode">
+                        <label class="checkbox-inline"><input type="radio" value="Arp" name="mode" <?php if (config::byKey('cmd_arp', 'ping') == '') {
+                                                                                                        print(" disabled");
+                                                                                                    } ?> />Arp</label>
+                        <label class="checkbox-inline"><input type="radio" value="Icmp" name="mode" <?php if (config::byKey('cmd_ping', 'ping') == '') {
+                                                                                                        print(" disabled");
+                                                                                                    } ?> />Icmp</label>
+                        <label class="checkbox-inline"><input type="radio" value="Tcp" name="mode" />Tcp</label>
                     </div>
                 </div>
                 <div class="form-group" id=ip>
                     <label class="col-lg-2 control-label">{{IP de l'équipement}}</label>
                     <div class="col-lg-3">
-                        <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="ip"/>
+                        <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="ip" />
                     </div>
                 </div>
                 <div class="form-group" id=mac>
                     <label class="col-lg-2 control-label">{{Adresse MAC de l'équipement}}</label>
                     <div class="col-lg-3">
-                        <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="mac"/>
+                        <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="mac" />
                     </div>
                 </div>
                 <div class="form-group" id=interface>
                     <label class="col-lg-2 control-label">{{Interface de recherche}}</label>
                     <div class="col-lg-3">
-                        <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="interface"/>
+                        <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="interface" />
                     </div>
-					<div class="col-lg-3">
-					{{Utile uniquement lorsque votre Jeedom possède plusieurs interfaces réseaux}}
-					</div>
-				</div>
+                    <div class="col-lg-3">
+                        {{Utile uniquement lorsque votre Jeedom possède plusieurs interfaces réseaux}}
+                    </div>
+                </div>
                 <div class="form-group" id="port">
                     <label class="col-lg-2 control-label">{{Port TCP}}</label>
                     <div class="col-lg-3">
-                        <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="port"/>
+                        <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="port" />
                     </div>
                 </div>
-            </fieldset> 
+            </fieldset>
         </form>
 
         <legend>{{Indicateurs}}</legend>
@@ -156,7 +160,7 @@ sendVarToJS('eqType', 'ping');
             <thead>
                 <tr>
                     <th>{{Nom}}</th>
-					<th style="width: 120px;">{{Icône}}</th>
+                    <th style="width: 120px;">{{Icône}}</th>
                     <th style="width: 120px;">{{Sous-Type}}</th>
                     <th style="width: 120px;">{{Paramètres}}</th>
                     <th style="width: 100px;">{{Action}}</th>

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -18,7 +18,7 @@
 require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
 include_file('core', 'authentification', 'php');
 if (!isConnect('admin')) {
-	throw new Exception('{{401 - Accès non autorisé}}');
+    throw new Exception('{{401 - Accès non autorisé}}');
 }
 ?>
 
@@ -26,24 +26,22 @@ if (!isConnect('admin')) {
     <div class="form-group">
         <label class="col-lg-4 control-label">{{Commande ping}}</label>
         <div class="col-lg-3">
-            <input class="configKey form-control" data-l1key="cmd_ping" disabled/>
+            <input class="configKey form-control" data-l1key="cmd_ping" disabled />
         </div>
     </div>
     <div class="form-group">
         <label class="col-lg-4 control-label">{{Commande arp-scan}}</label>
         <div class="col-lg-3">
-            <input class="configKey form-control" data-l1key="cmd_arp" disabled/>
+            <input class="configKey form-control" data-l1key="cmd_arp" disabled />
         </div>
     </div>
-	<div id='div_DetectBin' style="display: none;"></div>
+    <div id='div_DetectBin' style="display: none;"></div>
     <div class="form-group">
-		<div class="col-lg-4">
-		</div>
-		<div class="col-lg-3">
-			<a class="btn btn-warning" id="bt_DetectBin" style="color : white;"><i class="fa fa-wrench"></i> {{Detecter les programme ping et arp-scan}}</a>
-		</div>
+        <div class="col-lg-4">
+        </div>
+        <div class="col-lg-3">
+            <a class="btn btn-warning" id="bt_DetectBin" style="color : white;"><i class="fa fa-wrench"></i> {{Detecter les programme ping et arp-scan}}</a>
+        </div>
     </div>
 </form>
 <?php include_file('desktop', 'ping', 'js', 'ping'); ?>
-
-

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -60,4 +60,3 @@ function ping_remove() {
 		$cron->remove();
 	}
 }
-?>


### PR DESCRIPTION
Bonjour,

Suggestion pratique qui permet d'obtenir l'adresse IP à partir d'une adresse MAC en mode ARP. c'est utile pour tous les 
plugin basés sur des adresses IP dans un réseau en adressage dynamique, ou dans un réseau limité à 10 adresses IP fixes (SFR BOX)...

c'est aussi très pratique pour identifier les périphériques à partis de leur IP... 

**3 cas  :**

- Jamais détecté : "!.!"
- IP courante : "192.168.xxx.xxx"
- Dernière IP utilisée : "!192.168.xxx.xxx!"

**Exemple avec la widget info :**

![image](https://user-images.githubusercontent.com/46494287/94603973-4b34c980-0297-11eb-86bc-b9fab7eab7c5.png)


J'ai en même temps fait un peu de formatage (automatique sur vscode), 2 ou 3 améliorations graphiques et adapté la commande ARP pour la rendre plus rapide et plus efficace sur des réseaux mixtes (switch, lan, wifi)
   